### PR TITLE
Update views.py

### DIFF
--- a/scripts/views.py
+++ b/scripts/views.py
@@ -135,6 +135,7 @@ def render_view_using_file(obj_title, scadfile, dir, view, hashchanged, hash="")
         openscad.run(
                     "--imgsize=%d,%d" % (w, h),
                     "--projection=p",
+                    "--render",
                     "--camera=" + camera,
                     "-o", png_name,
                     scadfile)


### PR DESCRIPTION
to generate "rendered" images instead of preview images as some objects not rendered correctly because of the "goldfeather" setting in openscad. Takes longer to build the project but gives more error-free images